### PR TITLE
fix(clGetDeviceIDs): check error

### DIFF
--- a/eradicate2.cpp
+++ b/eradicate2.cpp
@@ -47,7 +47,10 @@ std::vector<cl_device_id> getAllDevices(cl_device_type deviceType = CL_DEVICE_TY
 		clGetDeviceIDs(*it, deviceType, 0, NULL, &countDevice);
 
 		std::vector<cl_device_id> deviceIds(countDevice);
-		clGetDeviceIDs(*it, deviceType, countDevice, deviceIds.data(), &countDevice);
+		if (clGetDeviceIDs(*it, deviceType, countDevice, deviceIds.data(), &countDevice) != CL_SUCCESS) {
+			continue;
+		}
+
 
 		std::copy( deviceIds.begin(), deviceIds.end(), std::back_inserter(vDevices) );
 	}
@@ -321,7 +324,7 @@ int main(int argc, char * * argv) {
 			const auto globalMemSize = clGetWrapper<cl_ulong>(clGetDeviceInfo, deviceId, CL_DEVICE_GLOBAL_MEM_SIZE);
 
 			std::cout << "  GPU" << i << ": " << strName << ", " << globalMemSize << " bytes available, " << computeUnits << " compute units" << std::endl;
-			vDevices.push_back(vFoundDevices[i]);
+			vDevices.push_back(deviceId);
 			mDeviceIndex[vFoundDevices[i]] = i;
 		}
 


### PR DESCRIPTION
Applying fix from https://github.com/wjmelements

see <https://github.com/johguse/ERADICATE2/pull/23>


Fixes: 

```
-33 is CL_INVALID_DEVICE.
I hunted down the origin of the corruption and determined it was an unhandled error.

Changes
Check the return value of clGetDeviceIDs
```
https://github.com/johguse/ERADICATE2/compare/master...wjmelements:ERADICATE2:clGetDeviceIDs-error#files_bucket